### PR TITLE
Fix code scanning alert no. 15: Server-side request forgery

### DIFF
--- a/services/src/main/java/org/jd/gui/service/fileloader/ZipFileLoaderProvider.java
+++ b/services/src/main/java/org/jd/gui/service/fileloader/ZipFileLoaderProvider.java
@@ -24,6 +24,10 @@ import java.util.Iterator;
 public class ZipFileLoaderProvider extends AbstractFileLoaderProvider {
     protected static final String[] EXTENSIONS = { "zip" };
 
+    private boolean isValidScheme(String scheme) {
+        return "file".equals(scheme);
+    }
+
     @Override
     public String[] getExtensions() { return EXTENSIONS; }
     @Override
@@ -39,6 +43,9 @@ public class ZipFileLoaderProvider extends AbstractFileLoaderProvider {
     public boolean load(API api, File file) {
         try {
             URI fileUri = file.toURI();
+            if (!isValidScheme(fileUri.getScheme())) {
+                throw new URISyntaxException(fileUri.toString(), "Invalid URI scheme");
+            }
             URI uri = new URI("jar:" + fileUri.getScheme(), fileUri.getHost(), fileUri.getPath() + "!/", null);
 
             FileSystem fileSystem;


### PR DESCRIPTION
Fixes [https://github.com/nbauma109/jd-gui-duo/security/code-scanning/15](https://github.com/nbauma109/jd-gui-duo/security/code-scanning/15)

To fix the SSRF vulnerability, we need to ensure that the `URI` constructed from the user-provided `File` object is validated against a whitelist of allowed schemes or hosts. In this case, since the application is designed to handle local files, we can restrict the `URI` to only allow the "file" scheme.

1. Add a method to validate the `URI` scheme.
2. Use this method to check the `URI` before creating a new file system.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
