### PR TITLE
Bump com.github.nbauma109:netbeans-visual-diff-standalone from 2.0.45 to 2.0.46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,6 @@
     <project.scm.id>github.com</project.scm.id>
     <flatlaf.version>3.6.2</flatlaf.version>
     <transformer-api.version>4.0.58</transformer-api.version>
-    <netbeans-visual-diff-standalone.version>2.0.45</netbeans-visual-diff-standalone.version>
+    <netbeans-visual-diff-standalone.version>2.0.46</netbeans-visual-diff-standalone.version>
   </properties>
 </project>


### PR DESCRIPTION
Bumps com.github.nbauma109:netbeans-visual-diff-standalone from 2.0.45 to 2.0.46.