### PR TITLE
Bump com.github.nbauma109:transformer-api from 4.0.58 to 4.0.60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
          • JD-Core V1
          • JADX
        ====================================================================== -->
-    <transformer-api.version>4.0.58</transformer-api.version>
+    <transformer-api.version>4.0.60</transformer-api.version>
     <!-- ======================================================================
          NetBeans Visual Diff Standalone — Diff Component for Swing
          ======================================================================


### PR DESCRIPTION
Bumps com.github.nbauma109:transformer-api from 4.0.58 to 4.0.60.