### PR TITLE
Forward args from startup scripts

### DIFF
--- a/assembler/src/main/resources/jd-gui-duo.bat
+++ b/assembler/src/main/resources/jd-gui-duo.bat
@@ -5,4 +5,4 @@ jre\bin\java -ea ^
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED ^
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED ^
   --add-opens java.base/java.lang.ref=ALL-UNNAMED ^
-  -cp "lib/*" org.jd.gui.App
+  -cp "lib/*" org.jd.gui.App %*

--- a/assembler/src/main/resources/jd-gui-duo.command
+++ b/assembler/src/main/resources/jd-gui-duo.command
@@ -5,4 +5,4 @@ jre/bin/java -ea \
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED \
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED \
   --add-opens java.base/java.lang.ref=ALL-UNNAMED \
-  -cp "lib/*" org.jd.gui.App
+  -cp "lib/*" org.jd.gui.App "$@"

--- a/assembler/src/main/resources/jd-gui-duo.sh
+++ b/assembler/src/main/resources/jd-gui-duo.sh
@@ -5,4 +5,4 @@ jre/bin/java -ea \
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED \
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED \
   --add-opens java.base/java.lang.ref=ALL-UNNAMED \
-  -cp "lib/*" org.jd.gui.App
+  -cp "lib/*" org.jd.gui.App "$@"


### PR DESCRIPTION
Didn't test the .bat but I don't anticipate any issues.

In my use case, I wanted to directly open the jar when invoking the script, currently the args are being ignored.