### PR TITLE
Set working directory to script path

### DIFF
--- a/assembler/src/main/resources/jd-gui-duo.bat
+++ b/assembler/src/main/resources/jd-gui-duo.bat
@@ -1,4 +1,5 @@
 @echo off
+cd /d "%~dp0"
 jre\bin\java -ea ^
   --add-opens java.base/java.net=ALL-UNNAMED ^
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED ^

--- a/assembler/src/main/resources/jd-gui-duo.command
+++ b/assembler/src/main/resources/jd-gui-duo.command
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 jre/bin/java -ea \
   --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \

--- a/assembler/src/main/resources/jd-gui-duo.sh
+++ b/assembler/src/main/resources/jd-gui-duo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 jre/bin/java -ea \
   --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \


### PR DESCRIPTION
Fixes issue when script is added to PATH and called elsewhere. Currently, the Scoop manifest manually applies this fix on install: https://github.com/ScoopInstaller/Extras/blob/9c489fc622b06fc214c9f3d9940d5ee14c97a291/bucket/jd-gui-duo.json#L11