### PR TITLE
Fix relative path arguments passed to script

### DIFF
--- a/assembler/src/main/resources/jd-gui-duo.bat
+++ b/assembler/src/main/resources/jd-gui-duo.bat
@@ -1,9 +1,9 @@
 @echo off
-cd /d "%~dp0"
-jre\bin\java -ea ^
+set "DIR=%~dp0"
+"%DIR%jre\bin\java" -ea ^
   --add-opens java.base/java.net=ALL-UNNAMED ^
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED ^
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED ^
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED ^
   --add-opens java.base/java.lang.ref=ALL-UNNAMED ^
-  -cp "lib/*" org.jd.gui.App %*
+  -cp "%DIR%lib\*" org.jd.gui.App %*

--- a/assembler/src/main/resources/jd-gui-duo.command
+++ b/assembler/src/main/resources/jd-gui-duo.command
@@ -1,9 +1,9 @@
 #!/bin/bash
-cd "$(dirname "$0")"
-jre/bin/java -ea \
+DIR="$(dirname "$0")"
+"$DIR/jre/bin/java" -ea \
   --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED \
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED \
   --add-opens java.base/java.lang.ref=ALL-UNNAMED \
-  -cp "lib/*" org.jd.gui.App "$@"
+  -cp "$DIR/lib/*" org.jd.gui.App "$@"

--- a/assembler/src/main/resources/jd-gui-duo.sh
+++ b/assembler/src/main/resources/jd-gui-duo.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-cd "$(dirname "$0")"
-jre/bin/java -ea \
+DIR="$(dirname "$0")"
+"$DIR/jre/bin/java" -ea \
   --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED \
   --add-opens java.desktop/javax.swing.text=ALL-UNNAMED \
   --add-opens java.prefs/java.util.prefs=ALL-UNNAMED \
   --add-opens java.base/java.lang.ref=ALL-UNNAMED \
-  -cp "lib/*" org.jd.gui.App "$@"
+  -cp "$DIR/lib/*" org.jd.gui.App "$@"


### PR DESCRIPTION
Apologies, I haven't accounted for #267 when I made my previous PR (#268).

The script directory should be used as a path prefix instead of changing the directory.