### PR TITLE
Replace ambiguous labels in jar comparer with Left Only/Right Only

### DIFF
--- a/app/src/main/java/tim/jarcomp/EntryTableModel.java
+++ b/app/src/main/java/tim/jarcomp/EntryTableModel.java
@@ -103,11 +103,11 @@ public class EntryTableModel extends AbstractTableModel {
      */
     private static String getText(EntryStatus inStatus) {
         return switch (inStatus) {
-            case ADDED -> "Added";
+            case ADDED -> "Right Only";
             case CHANGED_SIZE -> "Changed size";
             case CHANGED_SUM -> "Changed sum";
             case EQUAL -> "=";
-            case REMOVED -> "Removed";
+            case REMOVED -> "Left Only";
             case SAME_SIZE -> "Same size";
             default -> inStatus.toString();
         };

--- a/app/src/main/java/tim/jarcomp/EntryTableModel.java
+++ b/app/src/main/java/tim/jarcomp/EntryTableModel.java
@@ -103,11 +103,11 @@ public class EntryTableModel extends AbstractTableModel {
      */
     private static String getText(EntryStatus inStatus) {
         return switch (inStatus) {
-            case ADDED -> "Right Only";
+            case ADDED -> "Right only";
             case CHANGED_SIZE -> "Changed size";
             case CHANGED_SUM -> "Changed sum";
             case EQUAL -> "=";
-            case REMOVED -> "Left Only";
+            case REMOVED -> "Left only";
             case SAME_SIZE -> "Same size";
             default -> inStatus.toString();
         };


### PR DESCRIPTION
This pull request updates the status label text in the `EntryTableModel` to use more descriptive terms for added and removed entries.

Label improvements:

* Changed the label for `EntryStatus.ADDED` from "Added" to "Right Only" and for `EntryStatus.REMOVED` from "Removed" to "Left Only" in the `getText` method of `EntryTableModel.java`.