### PR TITLE
Fix session restore to save correct open files on shutdown

### DIFF
--- a/app/src/main/java/org/jd/gui/controller/MainController.java
+++ b/app/src/main/java/org/jd/gui/controller/MainController.java
@@ -220,6 +220,12 @@ public class MainController implements API {
         SwingUtil.invokeLater(() -> {
             // Show main frame
             mainView.show(configuration.getMainWindowLocation(), configuration.getMainWindowSize(), configuration.isMainWindowMaximize());
+            mainView.getMainFrame().addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    updateRememberedOpenFiles();
+                }
+            });
             if (!files.isEmpty()) {
                 openFiles(files);
             } else {
@@ -265,12 +271,6 @@ public class MainController implements API {
                 sourceLoaderService = new SourceLoaderService();
                 // Add listeners
                 mainFrame.addComponentListener(new MainFrameListener(configuration));
-                mainFrame.addWindowListener(new WindowAdapter() {
-                    @Override
-                    public void windowClosing(WindowEvent e) {
-                        updateRememberedOpenFiles();
-                    }
-                });
                 // Set drag and drop (DnD) files transfer handler
                 mainFrame.setTransferHandler(new FilesTransferHandler());
                 // Background class loading

--- a/app/src/main/java/org/jd/gui/controller/MainController.java
+++ b/app/src/main/java/org/jd/gui/controller/MainController.java
@@ -182,7 +182,7 @@ public class MainController implements API {
                 e -> onClose(),
                 e -> onSaveSource(),
                 e -> onSaveAllSources(),
-                e -> System.exit(0),
+                e -> onExit(),
                 e -> onCopy(),
                 e -> onPaste(),
                 e -> onSelectAll(),
@@ -357,6 +357,11 @@ public class MainController implements API {
                 }
         	}
         }
+    }
+
+    protected void onExit() {
+        updateRememberedOpenFiles();
+        System.exit(0);
     }
 
     protected void onClose() {

--- a/app/src/main/java/org/jd/gui/controller/MainController.java
+++ b/app/src/main/java/org/jd/gui/controller/MainController.java
@@ -86,6 +86,8 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -263,6 +265,12 @@ public class MainController implements API {
                 sourceLoaderService = new SourceLoaderService();
                 // Add listeners
                 mainFrame.addComponentListener(new MainFrameListener(configuration));
+                mainFrame.addWindowListener(new WindowAdapter() {
+                    @Override
+                    public void windowClosing(WindowEvent e) {
+                        updateRememberedOpenFiles();
+                    }
+                });
                 // Set drag and drop (DnD) files transfer handler
                 mainFrame.setTransferHandler(new FilesTransferHandler());
                 // Background class loading


### PR DESCRIPTION
updateRememberedOpenFiles() was only ever scheduled via invokeLater, so if the user closed tabs and then closed the window before the EDT processed those deferred calls, configuration.openFiles was never updated. The shutdown hook then persisted the stale list, causing the next startup to reopen files the user had already closed.

Fix by adding a windowClosing listener that calls updateRememberedOpenFiles() synchronously on the EDT right before System.exit() fires, guaranteeing that the correct set of open tabs is saved regardless of earlier timing.