### PR TITLE
Migrate crosspost workflow to per-platform actions

### DIFF
--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -1,8 +1,6 @@
 name: "Crosspost Release to Social Media"
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
     inputs:
       tag:
@@ -11,7 +9,7 @@ on:
         type: string
 
 env:
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+  RELEASE_TAG: ${{ github.event.inputs.tag }}
 
 jobs:
   validate:

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Post to Mastodon
-        uses: cbrgm/mastodon-github-action@v2
+        uses: cbrgm/mastodon-github-action@776364a15dd1171530479600c75363f7cbc89ef5 # v2
         with:
           access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
           url: https://${{ secrets.MASTODON_HOST }}
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Post to Bluesky
-        uses: cbrgm/bluesky-github-action@v1
+        uses: cbrgm/bluesky-github-action@d643d172e122e8ced65f2bd5061b6e77c5146c07 # v1
         with:
           handle: ${{ secrets.BLUESKY_IDENTIFIER }}
           password: ${{ secrets.BLUESKY_PASSWORD }}
@@ -52,28 +52,35 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create release post
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           mkdir -p posts
-          cat > "posts/release-${{ env.RELEASE_TAG }}.md" << 'EOF'
+          POST_FILE="posts/release-${RELEASE_TAG}.md"
+          if [ ! -f "$POST_FILE" ]; then
+            cat > "$POST_FILE" << EOF
           ---
-          title: "${{ github.event.repository.name }} ${{ env.RELEASE_TAG }} Released"
+          title: "${REPOSITORY_NAME} ${RELEASE_TAG} Released"
           published: true
-          description: "New release of ${{ github.event.repository.name }}"
+          description: "New release of ${REPOSITORY_NAME}"
           tags: java, decompiler, opensource, reverseengineering
           ---
 
-          🎉 New release of [${{ github.event.repository.name }}](https://github.com/${{ github.repository }}) is out!
+          🎉 New release of [${REPOSITORY_NAME}](https://github.com/${REPOSITORY}) is out!
 
-          Check out the [release notes](https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}).
+          Check out the [release notes](https://github.com/${REPOSITORY}/releases/tag/${RELEASE_TAG}).
           EOF
+          fi
       - name: Publish to Dev.to
-        uses: sinedied/publish-devto@v2
+        uses: sinedied/publish-devto@85426e8090533468bb8012015451e3af797b65af # v2
         with:
           devto_key: ${{ secrets.DEVTO_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'posts/release-*.md'
+          files: 'posts/release-${{ env.RELEASE_TAG }}.md'
           branch: master
           conventional_commits: false
 
@@ -84,7 +91,7 @@ jobs:
       contents: read
     steps:
       - name: Post Show HN
-        uses: higgins/action-hackernews-post@v1.0.1
+        uses: higgins/action-hackernews-post@74acdeb91fd56c6e46a448351515932c0b2ce049 # v1.0.1
         with:
           HN_USERNAME: ${{ secrets.HN_USERNAME }}
           HN_PASSWORD: ${{ secrets.HN_PASSWORD }}

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -14,8 +14,20 @@ env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
 
 jobs:
+  validate:
+    name: "Validate release exists"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}"
+
   mastodon:
     name: "Post to Mastodon"
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,6 +44,7 @@ jobs:
 
   bluesky:
     name: "Post to Bluesky"
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,6 +61,7 @@ jobs:
 
   devto:
     name: "Publish to Dev.to"
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -59,8 +73,8 @@ jobs:
           REPOSITORY_NAME: ${{ github.event.repository.name }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          mkdir -p posts
           POST_FILE="posts/release-${RELEASE_TAG}.md"
+          mkdir -p "$(dirname "$POST_FILE")"
           if [ ! -f "$POST_FILE" ]; then
             cat > "$POST_FILE" << EOF
           ---
@@ -86,6 +100,7 @@ jobs:
 
   hackernews:
     name: "Post to HackerNews"
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Post to Mastodon
-        uses: cbrgm/mastodon-github-action@776364a15dd1171530479600c75363f7cbc89ef5 # v2
+        uses: cbrgm/mastodon-github-action@776364a15dd1171530479600c75363f7cbc89ef5 # v2.2.0
         with:
           access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
           url: https://${{ secrets.MASTODON_HOST }}
@@ -50,7 +50,7 @@ jobs:
       contents: read
     steps:
       - name: Post to Bluesky
-        uses: cbrgm/bluesky-github-action@d643d172e122e8ced65f2bd5061b6e77c5146c07 # v1
+        uses: cbrgm/bluesky-github-action@d643d172e122e8ced65f2bd5061b6e77c5146c07 # v1.2.5
         with:
           handle: ${{ secrets.BLUESKY_IDENTIFIER }}
           password: ${{ secrets.BLUESKY_PASSWORD }}
@@ -90,7 +90,7 @@ jobs:
           EOF
           fi
       - name: Publish to Dev.to
-        uses: sinedied/publish-devto@85426e8090533468bb8012015451e3af797b65af # v2
+        uses: sinedied/publish-devto@c713cc0934b35cb3df9fca759b98e36e6a540a85 # v2
         with:
           devto_key: ${{ secrets.DEVTO_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Verify release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release view "${{ env.RELEASE_TAG }}" --repo "${{ github.repository }}"
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        run: gh release view "$RELEASE_TAG" --repo "${{ github.repository }}"
 
   mastodon:
     name: "Post to Mastodon"
@@ -99,7 +100,7 @@ jobs:
           conventional_commits: false
 
   hackernews:
-    name: "Post to HackerNews"
+    name: "Post to Hacker News"
     needs: validate
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -10,27 +10,83 @@ on:
         required: true
         type: string
 
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
 jobs:
-  crosspost:
-    name: "Crosspost to Social Media"
+  mastodon:
+    name: "Post to Mastodon"
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Crosspost to Bluesky, Mastodon, and Dev.to
-        uses: tgagor/action-crosspost@9523ff489bc74e1a9849c5d3071b6bcbad40042d # v1.6.3
+      - name: Post to Mastodon
+        uses: cbrgm/mastodon-github-action@v2
         with:
-          feed-url: https://github.com/${{ github.repository }}/releases.atom
-          limit: 1
-          filter-urls: |
-            /releases/tag/${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          url: ${{ secrets.MASTODON_HOST }}
           message: |
-            🎉 New release of ${{ github.event.repository.name }} is out!
-            {url}
+            🎉 New release of ${{ github.event.repository.name }} ${{ env.RELEASE_TAG }} is out!
+            https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}
             #Java #JavaDecompiler #OpenSource #ReverseEngineering
-          bluesky-host: bsky.social
-          bluesky-identifier: ${{ secrets.BLUESKY_IDENTIFIER }}
-          bluesky-password: ${{ secrets.BLUESKY_PASSWORD }}
-          mastodon-access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
-          mastodon-host: ${{ secrets.MASTODON_HOST }}
-          devto-api-key: ${{ secrets.DEVTO_API_KEY }}
+
+  bluesky:
+    name: "Post to Bluesky"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Post to Bluesky
+        uses: cbrgm/bluesky-github-action@v1
+        with:
+          handle: ${{ secrets.BLUESKY_IDENTIFIER }}
+          password: ${{ secrets.BLUESKY_PASSWORD }}
+          text: |
+            🎉 New release of ${{ github.event.repository.name }} ${{ env.RELEASE_TAG }} is out!
+            https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}
+            #Java #JavaDecompiler #OpenSource #ReverseEngineering
+
+  devto:
+    name: "Publish to Dev.to"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release post
+        run: |
+          mkdir -p posts
+          cat > "posts/release-${{ env.RELEASE_TAG }}.md" << 'EOF'
+          ---
+          title: "${{ github.event.repository.name }} ${{ env.RELEASE_TAG }} Released"
+          published: true
+          description: "New release of ${{ github.event.repository.name }}"
+          tags: java, decompiler, opensource, reverseengineering
+          ---
+
+          🎉 New release of [${{ github.event.repository.name }}](https://github.com/${{ github.repository }}) is out!
+
+          Check out the [release notes](https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}).
+          EOF
+      - name: Publish to Dev.to
+        uses: sinedied/publish-devto@v2
+        with:
+          devto_key: ${{ secrets.DEVTO_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'posts/release-*.md'
+          branch: master
+          conventional_commits: false
+
+  hackernews:
+    name: "Post to HackerNews"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Post Show HN
+        uses: higgins/action-hackernews-post@v1.0.1
+        env:
+          HN_USERNAME: ${{ secrets.HN_USERNAME }}
+          HN_PASSWORD: ${{ secrets.HN_PASSWORD }}
+          POST_TITLE: "Show HN: ${{ github.event.repository.name }} ${{ env.RELEASE_TAG }}"
+          POST_URL: "https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}"

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -24,7 +24,7 @@ jobs:
         uses: cbrgm/mastodon-github-action@v2
         with:
           access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
-          url: ${{ secrets.MASTODON_HOST }}
+          url: https://${{ secrets.MASTODON_HOST }}
           message: |
             🎉 New release of ${{ github.event.repository.name }} ${{ env.RELEASE_TAG }} is out!
             https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Post Show HN
         uses: higgins/action-hackernews-post@v1.0.1
-        env:
+        with:
           HN_USERNAME: ${{ secrets.HN_USERNAME }}
           HN_PASSWORD: ${{ secrets.HN_PASSWORD }}
           POST_TITLE: "Show HN: ${{ github.event.repository.name }} ${{ env.RELEASE_TAG }}"

--- a/.github/workflows/crosspost.yml
+++ b/.github/workflows/crosspost.yml
@@ -102,6 +102,7 @@ jobs:
   hackernews:
     name: "Post to Hacker News"
     needs: validate
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/distribution-submission.md
+++ b/docs/distribution-submission.md
@@ -106,16 +106,16 @@ API posting cost:
   - https://developers.forem.com/
   - https://developers.forem.com/api/v0
 
-### HackerNews
+### Hacker News
 
-- `HN_USERNAME` — your Hacker News username
-- `HN_PASSWORD` — your Hacker News password
+- `HN_USERNAME` — the username for a dedicated posting-only Hacker News account used by this workflow
+- `HN_PASSWORD` — the password for that dedicated posting-only Hacker News account
 
-Each release is submitted as a **Show HN** post with the release URL. HackerNews has no API key system; the action authenticates with your account credentials directly.
+Each release is submitted as a **Show HN** post with the release URL. Hacker News has no API key or scoped app-password system, so the action authenticates with full account credentials directly. Do not use a maintainer's primary personal Hacker News account; create a separate posting-only account and store only that account's credentials in `HN_USERNAME` and `HN_PASSWORD`.
 
 API posting cost:
 
-- Free (`$0`). HackerNews has no paid API or posting tier.
+- Free (`$0`). Hacker News has no paid API or posting tier.
 
 ### GitHub token for downstream workflow dispatch
 

--- a/docs/distribution-submission.md
+++ b/docs/distribution-submission.md
@@ -106,6 +106,17 @@ API posting cost:
   - https://developers.forem.com/
   - https://developers.forem.com/api/v0
 
+### HackerNews
+
+- `HN_USERNAME` — your Hacker News username
+- `HN_PASSWORD` — your Hacker News password
+
+Each release is submitted as a **Show HN** post with the release URL. HackerNews has no API key system; the action authenticates with your account credentials directly.
+
+API posting cost:
+
+- Free (`$0`). HackerNews has no paid API or posting tier.
+
 ### GitHub token for downstream workflow dispatch
 
 - `PAT_TOKEN`


### PR DESCRIPTION
Replace tgagor/action-crosspost with dedicated actions for each platform: cbrgm/mastodon-github-action, cbrgm/bluesky-github-action, sinedied/publish-devto, and higgins/action-hackernews-post (Show HN).

Each platform runs as an independent job so failures are isolated. Dev.to publishes a release article from a generated markdown file. HackerNews requires new HN_USERNAME and HN_PASSWORD secrets.